### PR TITLE
Fix TEMPFILE definition in docker-autocommit.

### DIFF
--- a/bin/docker-autocommit
+++ b/bin/docker-autocommit
@@ -159,7 +159,7 @@ create_base_dockerfile
 
 if [ -z $COMMAND ]
 then
-    export TEMPFILE=$(tempfile)
+    export TEMPFILE=/tmp/file${RANDOM}
     aliases_monitor &
     docker run -t -i $DOCKER_RUN_ARGS /bin/bash -c 'echo "shopt -s histappend; PROMPT_COMMAND=\"history -w;$PROMPT_COMMAND\"; rm .bash_history 2>/dev/null; history -c" >> /etc/profile.d/inmediately-save-history.sh; /bin/bash --login; rm /etc/profile.d/inmediately-save-history.sh; sleep 0.1; test -e ~/.bash_history && rm ~/.bash_history'
     #docker commit


### PR DESCRIPTION
tempfile command is provided by debianutis package, which is not available in non debian based systems, so TEMPFILE is not defined and produces an ambiguous redirect.
